### PR TITLE
Added support for strings as an alternative input

### DIFF
--- a/src/xxHash32.test.ts
+++ b/src/xxHash32.test.ts
@@ -23,6 +23,11 @@ describe('Validate xxHash32', () => {
             units: units[i % 3],
         });
         it(`Test random string: "${text.slice(0, 30).replace(/^(.{20}).*$/, '$1...')}"`, () => {
+            const actual = xxHash32(text).toString(16);
+            const expected = xxh.h32(text, 0).toString(16);
+            expect(actual).to.be.equal(expected);
+        });
+        it(`Test random string (as buffer): "${text.slice(0, 30).replace(/^(.{20}).*$/, '$1...')}"`, () => {
             const buffer = Buffer.from(text, 'utf8');
             const actual = xxHash32(buffer).toString(16);
             const expected = xxh.h32(buffer, 0).toString(16);

--- a/src/xxHash32.ts
+++ b/src/xxHash32.ts
@@ -12,7 +12,7 @@ const PRIME32_5 =  374761393;
  * @param seed - optional seed (32-bit unsigned);
  */
 export function xxHash32(buffer: Uint8Array | string, seed: number = 0): number {
-    buffer = buffer instanceof Buffer ? buffer : Buffer.from(buffer, 'utf8')
+    buffer = typeof buffer === "string" ? Buffer.from(buffer, 'utf8') : buffer
     const b = buffer;
 
     /*

--- a/src/xxHash32.ts
+++ b/src/xxHash32.ts
@@ -8,10 +8,11 @@ const PRIME32_5 =  374761393;
 
 /**
  *
- * @param buffer - byte array
+ * @param buffer - byte array or string
  * @param seed - optional seed (32-bit unsigned);
  */
-export function xxHash32(buffer: Uint8Array, seed: number = 0): number {
+export function xxHash32(buffer: Uint8Array | string, seed: number = 0): number {
+    buffer = buffer instanceof Buffer ? buffer : Buffer.from(buffer, 'utf8')
     const b = buffer;
 
     /*


### PR DESCRIPTION
This is a convenient change to integrate this library in web frameworks, for instance where you have a middleware to calculate the etag of the response payload.

See the work going on in https://github.com/fastify/fastify-etag/pull/7